### PR TITLE
Add group size check in SendData function

### DIFF
--- a/BattleScrolls/network/dpsshare.lua
+++ b/BattleScrolls/network/dpsshare.lua
@@ -154,6 +154,10 @@ end
 ---@param rawHPS number Raw healing per second output
 ---@param effectiveHPS number Effective healing per second output
 function dpsShare:SendData(allTargetsDPS, bossDPS, rawHPS, effectiveHPS)
+    local groupSize = GetGroupSize()
+    if groupSize == 0 then
+        return
+    end
     -- Network: still old format (phase 1)
     if dpsShare.legacyProtocol then
         dpsShare.legacyProtocol:Send({


### PR DESCRIPTION
Resolves a LibGroupBroadcast API warning.
```Lua
Tried to send data for protocol 'BattleScrolls_DPSHPSData' while not grouped
|rstack traceback:
user:/AddOns/LibDebugLogger/LogHandler.lua:206: in function 'Log'
(tail call): ?
user:/AddOns/LibGroupBroadcast/protocol/Protocol.lua:203: in function 'Protocol:Send'
user:/AddOns/BattleScrolls/network/dpsshare.lua:163: in function 'dpsShare:SendData'
user:/AddOns/BattleScrolls/network/dpssender.lua:26: in function 'dpsSender:OnCombatTick'
user:/AddOns/BattleScrolls/combat/ticker.lua:46: in function 'tick'
user:/AddOns/BattleScrolls/combat/ticker.lua:55: in function 'combatTicker:OnStatePreReset'
user:/AddOns/BattleScrolls/combat/state.lua:284: in function 'BattleScrolls.state:NotifyPreReset'
user:/AddOns/BattleScrolls/combat/state.lua:292: in function 'BattleScrolls.state:Reset'
user:/AddOns/BattleScrolls/combat/scribe.lua:284: in function 'scribe:FinalizeEncounter'
user:/AddOns/BattleScrolls/combat/scribe.lua:290: in function 'func'
/EsoUI/Libraries/Globals/globalapi.lua:282: in function '(anonymous)'
```