### PR TITLE
Clear async coroutine refs after fiber completion; drop large tables after encode/decode steps

### DIFF
--- a/BattleScrolls/combat/scribe.lua
+++ b/BattleScrolls/combat/scribe.lua
@@ -809,6 +809,7 @@ function scribe:ImportEncounterFromStateAsync()
         instance._instanceDataVersion = encodedFields._instanceDataVersion
         table.insert(instance.encounters, compactEncounter)
         instance._estimatedSize = nil
+        encounter = nil -- compact form is on instance; drop full table from the async stack
 
         LibEffect.YieldWithGC():Await()
 

--- a/BattleScrolls/core/effect.lua
+++ b/BattleScrolls/core/effect.lua
@@ -329,7 +329,7 @@ function Effect.Yield()
     return yieldEffect
 end
 
----Create an Effect that yields and requests GC
+---Create an Effect that yields and requests GC (unreachable objects only; not Async stack locals).
 ---@return Effect<nil>
 function Effect.YieldWithGC()
     return yieldWithGCEffect
@@ -552,6 +552,21 @@ local function runAsync(effect, fiber, onDone)
     local nextSuccess, nextValue  -- arguments for next resume
     local task = getTask(fiber)
 
+    -- Clear thread ref when the fiber finishes or is cancelled (suspended threads stay reachable while referenced).
+    local function releaseCoroutine()
+        co = nil
+    end
+
+    local function finishCancelled()
+        releaseCoroutine()
+        onDone(false, CancelledError.New())
+    end
+
+    local function finishDone(success, value)
+        releaseCoroutine()
+        onDone(success, value)
+    end
+
     -- Set up cancellation
     fiber._cancelFn = function()
         cancelled = true
@@ -560,12 +575,12 @@ local function runAsync(effect, fiber, onDone)
 
     local function step()
         if cancelled then
-            onDone(false, CancelledError.New())
+            finishCancelled()
             return
         end
 
         if coroutine.status(co) == "dead" then
-            onDone(false, "coroutine died unexpectedly (engine frame budget exceeded?)")
+            finishDone(false, "coroutine died unexpectedly (engine frame budget exceeded?)")
             return
         end
 
@@ -573,12 +588,12 @@ local function runAsync(effect, fiber, onDone)
         local ok, yielded = coroutine.resume(co, nextSuccess, nextValue)
 
         if not ok then
-            onDone(false, yielded)
+            finishDone(false, yielded)
             return
         end
 
         if coroutine.status(co) == "dead" then
-            onDone(true, yielded)
+            finishDone(true, yielded)
             return
         end
 
@@ -587,7 +602,7 @@ local function runAsync(effect, fiber, onDone)
             -- Awaiting a Fiber
             yielded:OnComplete(function(f)
                 if cancelled then
-                    onDone(false, CancelledError.New())
+                    finishCancelled()
                     return
                 end
                 nextSuccess = f:IsSucceeded()
@@ -610,7 +625,7 @@ local function runAsync(effect, fiber, onDone)
 
             runEffect(yielded, childFiber, function(success, value)
                 if cancelled then
-                    onDone(false, CancelledError.New())
+                    finishCancelled()
                     return
                 end
                 nextSuccess = success

--- a/BattleScrolls/core/gc.lua
+++ b/BattleScrolls/core/gc.lua
@@ -12,6 +12,7 @@
 -- provides a RequestGC() API that performs incremental GC
 -- in small steps, yielding between each. Cooldown equals
 -- the time the GC cycle took.
+-- Does not collect objects still held on a suspended Async coroutine stack.
 -----------------------------------------------------------
 
 if not SemisPlaygroundCheckAccess() then

--- a/BattleScrolls/ui/journal/pivot/engine.lua
+++ b/BattleScrolls/ui/journal/pivot/engine.lua
@@ -1002,7 +1002,8 @@ function engine.runDecodeQueryAsync(query, scopedEncounters, onProgress)
                     end
                 end
             end
-            -- decoded goes out of scope, GC can collect
+            -- Release decode before the next iteration (suspended Async keeps locals reachable).
+            decoded = nil
 
             if onProgress then onProgress(idx, #scopedEncounters) end
         end


### PR DESCRIPTION
## Summary

Reduces retention of large tables on suspended `LibEffect.Async` coroutines: clear the thread handle when a fiber completes or is cancelled, and drop heavy locals once compact data is stored or a pivot decode step finishes.

## Context

On ESO’s Lua runtime, a **suspended** coroutine stays reachable (locals/upvalues are not collected while the thread is still referenced). `Yield` / `YieldWithGC` only spread work across frames; they do not free values still held on the async stack. `RequestGC` cannot collect objects still reachable from a suspended thread.

## Changes

- **`core/effect.lua`**: On every terminal path in `runAsync` (success, error, cancel), nil the coroutine handle after `onDone`, so finished or cancelled fibers do not keep a suspended thread alive via the scheduler closure.
- **`combat/scribe.lua`**: `encounter = nil` after the compact encounter is stored on the instance.
- **`ui/journal/pivot/engine.lua`**: `decoded = nil` after each encounter in `runDecodeQueryAsync`.
- **`core/gc.lua`**, **`Effect.YieldWithGC`**: Comments that incremental GC does not reclaim stack-held async locals.

## Testing

Tested in-game on PC with ForceConsoleFlow enabled; encounter finalize/encode, journal tab changes, pivot query over multiple encounters.


Background measurements and API notes: [ESO coroutine findings (FINDINGS.md)](https://github.com/DakJaniels/ESOCoroutineTests/blob/main/FINDINGS.md)
